### PR TITLE
Roundup mutex and Node12 → Node16

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,7 +20,7 @@ jobs:
     if: github.actor != 'pdsen-ci'
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           token: ${{ secrets.ADMIN_GITHUB_TOKEN }}
 

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -34,7 +34,7 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL


### PR DESCRIPTION
## 📜 Summary

Merge this and you'll close (where applicable):

- [roundup-action#98](https://github.com/NASA-PDS/roundup-action/issues/98) in those repositories that use the Roundup Action. This merge adds a [mutex](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#concurrency) to Roundups so that only one can ever run at a time.
- [software-issues-repo#41](https://github.com/NASA-PDS/software-issues-repo/issues/41) in those repositories that use the `checkout` or `cache` actions. It upgrades those actions to version 3, as [version 2 is deprecated due to running older Node12](https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/).


## 🩺 Test Data and/or Report

None provided.


## 🧩 Related Issues

- [roundup-action#98](https://github.com/NASA-PDS/roundup-action/issues/98)
- [software-issues-repo#41](https://github.com/NASA-PDS/software-issues-repo/issues/41)
