### PR TITLE
Resolve #38

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,4 @@ sphinx==4.5.0
 sphinx-rtd-theme==1.1.1
 gitpython==3.1.30
 sphinxemoji
-pds-github-util==0.29.0
+lasso.issues~=1.0.1


### PR DESCRIPTION
## 🗒️ Summary

This replaces use of the monopolistic pds-github-util with lasso.issues. Merge this to resolve #38 and bring us one-step closer to retiring pds-github-util.

## ⚙️ Test Data and/or Report

Tested in the "sandbox" organization; see [the latest run](https://github.com/NASA-PDS/nasa-pds.github.io/pull/new/i38 ).

## ♻️ Related Issues

- #38 
