### PR TITLE
fix: checkout lasso-issues to /tmp to prevent it being committed to repo

### DIFF
--- a/.github/workflows/rdd-gen.yml
+++ b/.github/workflows/rdd-gen.yml
@@ -30,13 +30,13 @@ jobs:
         with:
           repository: NASA-PDS/lasso-issues
           ref: main
-          path: lasso-issues
+          path: /tmp/lasso-issues
           token: ${{ secrets.ADMIN_GITHUB_TOKEN }}
 
       - name: Install dependencies
         run: |
           pip install -r requirements.txt
-          pip install ./lasso-issues
+          pip install /tmp/lasso-issues
 
       - name: Generate RDD
         run: |


### PR DESCRIPTION
## Summary

- Changes `path: lasso-issues` to `path: /tmp/lasso-issues` in the `rdd-gen.yml` workflow so the `lasso-issues` checkout lands outside the GitHub workspace.
- Updates the `pip install` reference to match the new path.
- Prevents `git add -A .` in the commit step from picking up the `lasso-issues` directory and adding it to the repo on every RDD generation run.

## Test plan

- [ ] Trigger the workflow manually via `workflow_dispatch` and confirm `lasso-issues` does not appear in the resulting commit.

🤖 Generated with [Claude Code](https://claude.ai/claude-code)